### PR TITLE
Fix escaping on "Enable address matching"

### DIFF
--- a/cores/usb/doc/mem-map.md
+++ b/cores/usb/doc/mem-map.md
@@ -22,7 +22,7 @@ Global CSRs
   * `bra` : Bus Reset Asserted
   * `brp` : Bus Reset Pending
   * `sfp` : Start-of-Frame Pending
-  * 'm'   : Enable address matching
+  * `m`   : Enable address matching
   * `addr`: Configure address matching
 
 


### PR DESCRIPTION
The m felt left out.