### PR TITLE
e1-recorder: Add small 'dump' program

### DIFF
--- a/projects/riscv_usb/sw/Makefile
+++ b/projects/riscv_usb/sw/Makefile
@@ -2,9 +2,13 @@ CC=gcc
 CFLAGS=`pkg-config libusb-1.0 --cflags` -O2 -Wall
 LDLIBS=`pkg-config libusb-1.0 --libs`
 
-OBJS=main
+OBJS=main dump
+
+all: $(OBJS)
 
 main: idt82v2081.o idt82v2081_usb.o main.o
+
+dump: hexdump.o dump.o
 
 clean:
 	rm -f $(OBJS) *.o

--- a/projects/riscv_usb/sw/dump.c
+++ b/projects/riscv_usb/sw/dump.c
@@ -1,0 +1,114 @@
+/* (C) 2019 by Harald Welte <laforge@gnumonks.org>
+ * All Rights Reserved
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <string.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <getopt.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <errno.h>
+
+#include "hexdump.h"
+
+
+static uint8_t g_usb_endpoint = 0x81;
+
+#define E1_CHUNK_HDR_MAGIC	0xe115600d /* E1 is good */
+struct e1_chunk_hdr {
+	uint32_t magic;
+	struct {
+		uint64_t sec;
+		uint64_t usec;
+	} time;
+	uint16_t len;		/* length of following payload */
+	uint8_t ep;		/* USB endpoint */
+} __attribute__((packed));
+
+static int process_file(int fd)
+{
+	struct e1_chunk_hdr hdr;
+	unsigned long offset = 0;
+	uint8_t buf[65535];
+	int rc;
+
+	while (1) {
+		memset(buf, 0, sizeof(buf));
+		/* first read header */
+		rc = read(fd, &hdr, sizeof(hdr));
+		if (rc < 0)
+			return rc;
+		if (rc != sizeof(hdr)) {
+			fprintf(stderr, "%d is less than header size (%zd)\n", rc, sizeof(hdr));
+			return -1;
+		}
+		offset += rc;
+		if (hdr.magic != E1_CHUNK_HDR_MAGIC) {
+			fprintf(stderr, "offset %lu: Wrong magic 0x%08x\n", offset, hdr.magic);
+			return -1;
+		}
+
+		/* then read payload */
+		rc = read(fd, buf, hdr.len);
+		if (rc < 0)
+			return rc;
+		offset += rc;
+		if (rc != hdr.len) {
+			fprintf(stderr, "%d is less than payload size (%d)\n", rc, hdr.len);
+			return -1;
+		}
+
+		/* filter on the endpoint (direction) specified by the user */
+		if (hdr.ep != g_usb_endpoint)
+			continue;
+
+		if (hdr.len <= 4)
+			continue;
+
+		for (int i = 4; i < hdr.len-4; i += 32)
+			printf("%s\n", osmo_hexdump(buf+i, 32));
+	}
+}
+
+static int open_file(const char *fname)
+{
+	return open(fname, O_RDONLY);
+}
+
+int main(int argc, char **argv)
+{
+	char *fname;
+	int rc;
+
+	if (argc < 2) {
+		fprintf(stderr, "You must specify the file name of the ICE40-E1 capture\n");
+		exit(1);
+	}
+	fname = argv[1];
+
+	rc = open_file(fname);
+	if (rc < 0) {
+		fprintf(stderr, "Error opening %s: %s\n", fname, strerror(errno));
+		exit(1);
+	}
+	process_file(rc);
+}

--- a/projects/riscv_usb/sw/hexdump.c
+++ b/projects/riscv_usb/sw/hexdump.c
@@ -1,0 +1,76 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "hexdump.h"
+
+static char hexd_buff[4096];
+static const char hex_chars[] = "0123456789abcdef";
+
+/*! Convert binary sequence to hexadecimal ASCII string.
+ *  \param[out] out_buf  Output buffer to write the resulting string to.
+ *  \param[in] out_buf_size  sizeof(out_buf).
+ *  \param[in] buf  Input buffer, pointer to sequence of bytes.
+ *  \param[in] len  Length of input buf in number of bytes.
+ *  \param[in] delim  String to separate each byte; NULL or "" for no delim.
+ *  \param[in] delim_after_last  If true, end the string in delim (true: "1a:ef:d9:", false: "1a:ef:d9");
+ *                               if out_buf has insufficient space, the string will always end in a delim.
+ *  \returns out_buf, containing a zero-terminated string, or "" (empty string) if out_buf == NULL or out_buf_size < 1.
+ *
+ * This function will print a sequence of bytes as hexadecimal numbers, adding one delim between each byte (e.g. for
+ * delim passed as ":", return a string like "1a:ef:d9").
+ *
+ * The delim_after_last argument exists to be able to exactly show the original osmo_hexdump() behavior, which always
+ * ends the string with a delimiter.
+ */
+const char *osmo_hexdump_buf(char *out_buf, size_t out_buf_size, const unsigned char *buf, int len, const char *delim,
+			     bool delim_after_last)
+{
+	int i;
+	char *cur = out_buf;
+	size_t delim_len;
+
+	if (!out_buf || !out_buf_size)
+		return "";
+
+	delim = delim ? : "";
+	delim_len = strlen(delim);
+
+	for (i = 0; i < len; i++) {
+		const char *delimp = delim;
+		int len_remain = out_buf_size - (cur - out_buf) - 1;
+		if (len_remain < (2 + delim_len)
+		    && !(!delim_after_last && i == (len - 1) && len_remain >= 2))
+			break;
+
+		*cur++ = hex_chars[buf[i] >> 4];
+		*cur++ = hex_chars[buf[i] & 0xf];
+
+		if (i == (len - 1) && !delim_after_last)
+			break;
+
+		while (len_remain > 1 && *delimp) {
+			*cur++ = *delimp++;
+			len_remain--;
+		}
+	}
+	*cur = '\0';
+	return out_buf;
+}
+
+/*! Convert binary sequence to hexadecimal ASCII string
+ *  \param[in] buf pointer to sequence of bytes
+ *  \param[in] len length of buf in number of bytes
+ *  \returns pointer to zero-terminated string
+ *
+ * This function will print a sequence of bytes as hexadecimal numbers,
+ * adding one space character between each byte (e.g. "1a ef d9")
+ *
+ * The maximum size of the output buffer is 4096 bytes, i.e. the maximum
+ * number of input bytes that can be printed in one call is 1365!
+ */
+char *osmo_hexdump(const unsigned char *buf, int len)
+{
+	osmo_hexdump_buf(hexd_buff, sizeof(hexd_buff), buf, len, " ", true);
+	return hexd_buff;
+}

--- a/projects/riscv_usb/sw/hexdump.h
+++ b/projects/riscv_usb/sw/hexdump.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <stdbool.h>
+
+const char *osmo_hexdump_buf(char *out_buf, size_t out_buf_size, const unsigned char *buf, int len, const char *delim,
+			     bool delim_after_last);
+
+char *osmo_hexdump(const unsigned char *buf, int len);

--- a/projects/riscv_usb/sw/main.c
+++ b/projects/riscv_usb/sw/main.c
@@ -313,7 +313,7 @@ opts_help(void)
 static int
 opts_parse(struct options *opts, int argc, char *argv[])
 {
-	const char *opts_short = "ao:n:p:mh";
+	const char *opts_short = "ao:n:p:mrh";
 	int opt;
 
 	while ((opt = getopt(argc, argv, opts_short)) != -1)


### PR DESCRIPTION
This program will print one line for each E1 frame, where each line
consists of 32 hex bytes: one for each timeslot