### PR TITLE
Fix/riscv gcc toolchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build-tmp
 __pycache__
 .*.swp
+*~
+*.un~

--- a/projects/riscv_doom/fw_boot/Makefile
+++ b/projects/riscv_doom/fw_boot/Makefile
@@ -1,4 +1,4 @@
-CROSS ?= riscv-none-embed-
+CROSS ?= riscv-none-elf-
 
 CC = $(CROSS)gcc
 OBJCOPY = $(CROSS)objcopy

--- a/projects/riscv_usb/fw/Makefile
+++ b/projects/riscv_usb/fw/Makefile
@@ -1,5 +1,5 @@
 BOARD ?= icebreaker
-CROSS ?= riscv-none-embed-
+CROSS ?= riscv-none-elf-
 CC = $(CROSS)gcc
 OBJCOPY = $(CROSS)objcopy
 ICEPROG = iceprog

--- a/projects/usb_amr/fw/Makefile
+++ b/projects/usb_amr/fw/Makefile
@@ -1,5 +1,5 @@
 BOARD ?= icebreaker
-CROSS ?= riscv-none-embed-
+CROSS ?= riscv-none-elf-
 CC = $(CROSS)gcc
 OBJCOPY = $(CROSS)objcopy
 ICEPROG = iceprog

--- a/projects/usb_audio/fw/Makefile
+++ b/projects/usb_audio/fw/Makefile
@@ -1,5 +1,5 @@
 BOARD ?= icebreaker
-CROSS ?= riscv-none-embed-
+CROSS ?= riscv-none-elf-
 CC = $(CROSS)gcc
 OBJCOPY = $(CROSS)objcopy
 ICEPROG = iceprog


### PR DESCRIPTION
The riscv gcc toolchain has migrated from `riscv-none-embed-*` binaries to `riscv-none-elf-*` names.

https://github.com/xpack-dev-tools/riscv-none-embed-gcc-xpack#deprecated-replaced-by-xpack-dev-toolsriscv-none-elf-gcc-xpack

> This toolchain is now **end-of-life** and there will be no more releases.
>
> Please update your projects to use the new [`xpack-dev-tools/riscv-none-elf-gcc-xpack`](https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack).
